### PR TITLE
Possible bug in ipix calculation?

### DIFF
--- a/src/xy2pix.m
+++ b/src/xy2pix.m
@@ -67,6 +67,7 @@ ipf = ipf + (x2pix(ix+1) + y2pix(iy+1))*scale;
 
 ipix = ipf + nFace*nSide^2;
 
-ipix = ipix+1; % MEALPix numbering
+% Is this a bug?
+%ipix = ipix+1; % MEALPix numbering
 
 return


### PR DESCRIPTION
Above unchanged code (i.e. without the commenting out) gives:
2 = xy2pix(1,1,1,1)
13 = xy2pix(1,1,1,12)
After edits (i.e. %ipix = ipix+1;) it gives:
1 = xy2pix(1,1,1,1)
12 = xy2pix(1,1,1,12)